### PR TITLE
Add ResNet-based feature extraction pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,7 @@ __marimo__/
 
 # Project outputs
 *.png
+outputs/features/embeddings.npy
+outputs/features/embeddings.pt
+outputs/features/embeddings.csv
+!outputs/logs/feature_extraction.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# semi-supervised-image-processing
+# Semi-Supervised Image Processing
+
+Utilities for auditing and preprocessing the MRI brain cancer dataset used in
+semi-supervised experiments.
+
+## Environment setup
+
+```bash
+pip install -e .
+```
+
+This installs PyTorch, torchvision, and the supporting scientific Python stack
+needed by the audit and feature extraction scripts.
+
+## Dataset layout
+
+```
+mri_dataset_brain_cancer_oc/
+├── avec_labels/        # labeled images grouped by class
+└── sans_label/         # unlabeled study images
+```
+
+Place the dataset at the repository root (default assumption for the scripts).
+
+## Data audit (Task 1)
+
+Regenerate the exploratory audit assets (tables, plots, and notes):
+
+```bash
+python -m src.data_audit --data-dir mri_dataset_brain_cancer_oc --sample-size 64
+```
+
+Artifacts are written to `outputs/tables`, `outputs/figures`, and
+`outputs/notes/data_audit.md`.
+
+## Feature extraction (Task 2)
+
+The `src.feature_extraction` module builds a deterministic preprocessing
+pipeline (resize→center crop→tensor→ImageNet normalization) and extracts
+512-D embeddings using a frozen `torchvision` ResNet-18 backbone. Run the full
+inference pass with:
+
+```bash
+python -m src.feature_extraction \
+  --data-dir mri_dataset_brain_cancer_oc \
+  --device cpu            # or cuda if available \
+  --batch-size 32
+```
+
+Key artifacts are produced under `outputs/`:
+
+- `outputs/features/embeddings.npy` — NumPy array of [N, 512] features.
+- `outputs/features/embeddings.csv` — table aligning file paths to embedding
+  indices (ignored from Git by default).
+- `outputs/features/metadata.json` — reproducibility metadata (backbone,
+  transforms, dataset digest, sanity check statistics).
+- `outputs/logs/feature_extraction.log` — run log.
+- `outputs/notes/feature_summary.md` — short human-readable report with stats
+  and nearest-neighbor spot checks.
+
+Decode failures (if any) are logged and summarized in the markdown report so
+that problematic files can be investigated separately.

--- a/outputs/features/metadata.json
+++ b/outputs/features/metadata.json
@@ -1,0 +1,73 @@
+{
+  "backbone": "torchvision.resnet18",
+  "weights": "ResNet18_Weights.IMAGENET1K_V1",
+  "layer": "global_avg_pool",
+  "embedding_dimension": 512,
+  "input_resize": 256,
+  "input_crop": 224,
+  "normalization_mean": [
+    0.485,
+    0.456,
+    0.406
+  ],
+  "normalization_std": [
+    0.229,
+    0.224,
+    0.225
+  ],
+  "channel_policy": "PIL RGB conversion (grayscale replicated)",
+  "date_utc": "2025-10-01T14:12:27.289004+00:00",
+  "num_images": 1506,
+  "failed_images": 0,
+  "device": "cpu",
+  "dataset_dir": "mri_dataset_brain_cancer_oc",
+  "dataset_digest": "c96fb1c82f10414a9d2ced62b9504edcb834485738e0ab55411e760e0179680b",
+  "sanity_checks": {
+    "num_vectors": 1506,
+    "dimension": 512,
+    "mean_abs_mean": 0.8849999904632568,
+    "mean_std": 0.5817978382110596
+  },
+  "neighbor_probe": [
+    {
+      "query": "sans_label/04dd2b78-0aa3-4364-b762-21a6e71d3658.jpg",
+      "neighbor": "avec_labels/normal/b9b56b95-43de-4c35-8362-400e9271af71.jpg",
+      "similarity": 1.0
+    },
+    {
+      "query": "sans_label/b0573368-2b4a-4bb5-a2f2-fd4c106cbd6a.jpg",
+      "neighbor": "sans_label/2e671412-32fd-4136-9844-f7053b0696c9.jpg",
+      "similarity": 0.9307708740234375
+    },
+    {
+      "query": "sans_label/db87f1fa-f718-4bf4-821f-689d5d6e72a1.jpg",
+      "neighbor": "sans_label/33a6d838-67db-4ad2-a67a-b4d4b641ec8a.jpg",
+      "similarity": 0.8775182962417603
+    },
+    {
+      "query": "sans_label/a694549b-164f-4ab6-8c6e-821661302d50.jpg",
+      "neighbor": "sans_label/dd2eb4e7-90a3-4801-ab47-b94dee64eab2.jpg",
+      "similarity": 0.9453628063201904
+    },
+    {
+      "query": "sans_label/63ca22a2-f45f-44d9-9aae-00f4d9bd795a.jpg",
+      "neighbor": "sans_label/5434d6b2-b0dd-42d7-832c-ae465e64ddc2.jpg",
+      "similarity": 1.0
+    },
+    {
+      "query": "sans_label/65664115-d6c0-4d61-8708-1e8e36f1c193.jpg",
+      "neighbor": "sans_label/bb7be2dc-ad86-4c83-8350-c711317d5fb0.jpg",
+      "similarity": 0.9396051168441772
+    },
+    {
+      "query": "sans_label/05e808fc-a00c-4f1e-9682-1f73915f6902.jpg",
+      "neighbor": "sans_label/ecd494ef-9aed-48e7-a2a3-99c91b46bfed.jpg",
+      "similarity": 0.9999998807907104
+    },
+    {
+      "query": "sans_label/c38f8369-c2b1-41e3-a5ab-fd4c0cdafd3e.jpg",
+      "neighbor": "avec_labels/cancer/c6acea0d-0c31-4ce8-b0f8-b4a610a9477d.jpg",
+      "similarity": 0.8949753046035767
+    }
+  ]
+}

--- a/outputs/logs/feature_extraction.log
+++ b/outputs/logs/feature_extraction.log
@@ -1,0 +1,8 @@
+2025-10-01 14:11:26,690 [INFO] Starting feature extraction on device cpu
+2025-10-01 14:11:26,719 [INFO] Discovered 1506 images (labeled=100, unlabeled=1406)
+2025-10-01 14:11:27,979 [INFO] Beginning feature extraction over 1506 records
+2025-10-01 14:12:26,947 [INFO] Computed embeddings with shape (1506, 512)
+2025-10-01 14:12:26,952 [INFO] Completed embedding extraction in 60.23 seconds
+2025-10-01 14:12:26,956 [INFO] Embedding stats — vectors: 1506, dim: 512, mean(|mean|): 0.88500, mean(std): 0.58180
+2025-10-01 14:12:26,974 [INFO] Nearest-neighbor probe completed for 8 samples
+2025-10-01 14:12:27,296 [INFO] Artifacts saved to outputs/features

--- a/outputs/notes/feature_summary.md
+++ b/outputs/notes/feature_summary.md
@@ -1,0 +1,33 @@
+# Feature Extraction Summary
+
+- Backbone: torchvision.resnet18 (ResNet18_Weights.IMAGENET1K_V1)
+- Layer: global average pooled features (512-D)
+- Input spec: resize 256 → center crop 224, RGB conversion, ImageNet normalization
+- Batch size: 32
+- Device: cpu
+- Total images processed: 1506
+- Failed decodes: 0
+- Mean per-image latency (s): 0.0392
+- Median per-image latency (s): 0.0391
+
+## Sanity Check Statistics
+
+- Mean of |dimension means|: 0.885000
+- Mean of dimension standard deviations: 0.581798
+
+## Nearest Neighbor Spot Check
+
+| Query | Neighbor | Cosine |
+| --- | --- | --- |
+| sans_label/04dd2b78-0aa3-4364-b762-21a6e71d3658.jpg | avec_labels/normal/b9b56b95-43de-4c35-8362-400e9271af71.jpg | 1.0000 |
+| sans_label/b0573368-2b4a-4bb5-a2f2-fd4c106cbd6a.jpg | sans_label/2e671412-32fd-4136-9844-f7053b0696c9.jpg | 0.9308 |
+| sans_label/db87f1fa-f718-4bf4-821f-689d5d6e72a1.jpg | sans_label/33a6d838-67db-4ad2-a67a-b4d4b641ec8a.jpg | 0.8775 |
+| sans_label/a694549b-164f-4ab6-8c6e-821661302d50.jpg | sans_label/dd2eb4e7-90a3-4801-ab47-b94dee64eab2.jpg | 0.9454 |
+| sans_label/63ca22a2-f45f-44d9-9aae-00f4d9bd795a.jpg | sans_label/5434d6b2-b0dd-42d7-832c-ae465e64ddc2.jpg | 1.0000 |
+| sans_label/65664115-d6c0-4d61-8708-1e8e36f1c193.jpg | sans_label/bb7be2dc-ad86-4c83-8350-c711317d5fb0.jpg | 0.9396 |
+| sans_label/05e808fc-a00c-4f1e-9682-1f73915f6902.jpg | sans_label/ecd494ef-9aed-48e7-a2a3-99c91b46bfed.jpg | 1.0000 |
+| sans_label/c38f8369-c2b1-41e3-a5ab-fd4c0cdafd3e.jpg | avec_labels/cancer/c6acea0d-0c31-4ce8-b0f8-b4a610a9477d.jpg | 0.8950 |
+
+## Decode Failures
+
+None

--- a/src/feature_extraction.py
+++ b/src/feature_extraction.py
@@ -1,0 +1,511 @@
+"""Feature extraction pipeline for MRI brain cancer dataset.
+
+This module performs deterministic preprocessing and extracts
+fixed-length embeddings from a pretrained ResNet backbone. The
+implementation follows the workflow outlined for Task 2 of the
+semi-supervised image processing project:
+
+1. Discover all images in the labeled and unlabeled buckets.
+2. Apply resize / center-crop / normalization transforms compatible
+   with ImageNet pretraining.
+3. Run the frozen backbone in inference mode to produce embeddings for
+   each image, logging any decode failures along the way.
+4. Persist the embeddings, metadata, and summary artifacts to the
+   ``outputs`` directory tree.
+
+Run directly as a script to regenerate embeddings::
+
+    python -m src.feature_extraction --data-dir mri_dataset_brain_cancer_oc
+
+The script can be configured with additional CLI flags; run with
+``--help`` for details.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+import torch
+from PIL import Image, UnidentifiedImageError
+from torch import nn
+from torchvision import models, transforms
+
+# ---------------------------------------------------------------------------
+# Constants and configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_DATA_DIR = Path("mri_dataset_brain_cancer_oc")
+DEFAULT_OUTPUT_ROOT = Path("outputs")
+FEATURE_OUTPUT_DIR = DEFAULT_OUTPUT_ROOT / "features"
+LOG_OUTPUT_DIR = DEFAULT_OUTPUT_ROOT / "logs"
+NOTE_OUTPUT_DIR = DEFAULT_OUTPUT_ROOT / "notes"
+LOG_PATH = LOG_OUTPUT_DIR / "feature_extraction.log"
+EMBEDDING_ARRAY_PATH = FEATURE_OUTPUT_DIR / "embeddings.npy"
+EMBEDDING_CSV_PATH = FEATURE_OUTPUT_DIR / "embeddings.csv"
+METADATA_PATH = FEATURE_OUTPUT_DIR / "metadata.json"
+SUMMARY_NOTE_PATH = NOTE_OUTPUT_DIR / "feature_summary.md"
+
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+TARGET_RESIZE = 256
+TARGET_CROP = 224
+BATCH_SIZE = 32
+NEIGHBOR_SAMPLE = 8
+RNG_SEED = 42
+
+LABELED_BUCKET = "avec_labels"
+UNLABELED_BUCKET = "sans_label"
+
+BACKBONE_NAME = "torchvision.resnet18"
+BACKBONE_WEIGHTS = "ResNet18_Weights.IMAGENET1K_V1"
+BACKBONE_LAYER = "global_avg_pool"
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ImageRecord:
+    """Representation of a single image in the dataset."""
+
+    absolute_path: Path
+    relative_path: Path
+    bucket: str
+    label: Optional[str]
+
+
+@dataclass
+class ExtractionResults:
+    """Container for outputs generated during extraction."""
+
+    embeddings: np.ndarray
+    records: List[ImageRecord]
+    failures: List[Path]
+    per_file_times: List[float]
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+
+def configure_logging(verbose: bool = False) -> None:
+    """Configure logging to both stdout and the log file."""
+
+    LOG_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    handlers: List[logging.Handler] = [
+        logging.FileHandler(LOG_PATH, mode="w", encoding="utf-8"),
+        logging.StreamHandler(),
+    ]
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=handlers,
+    )
+
+
+def discover_image_records(data_dir: Path) -> List[ImageRecord]:
+    """Enumerate labeled and unlabeled images as :class:`ImageRecord`s."""
+
+    if not data_dir.exists():
+        raise FileNotFoundError(f"Data directory not found: {data_dir}")
+
+    records: List[ImageRecord] = []
+    # Labeled bucket: expect label folders inside ``avec_labels``
+    labeled_root = data_dir / LABELED_BUCKET
+    if labeled_root.exists():
+        for label_dir in sorted(p for p in labeled_root.iterdir() if p.is_dir()):
+            label = label_dir.name
+            for image_path in sorted(label_dir.rglob("*")):
+                if image_path.is_file():
+                    relative = image_path.relative_to(data_dir)
+                    records.append(
+                        ImageRecord(
+                            absolute_path=image_path,
+                            relative_path=relative,
+                            bucket="labeled",
+                            label=label,
+                        )
+                    )
+    else:
+        logging.warning("Labeled bucket missing at %s", labeled_root)
+
+    # Unlabeled bucket: files directly under ``sans_label``
+    unlabeled_root = data_dir / UNLABELED_BUCKET
+    if unlabeled_root.exists():
+        for image_path in sorted(unlabeled_root.rglob("*")):
+            if image_path.is_file():
+                relative = image_path.relative_to(data_dir)
+                records.append(
+                    ImageRecord(
+                        absolute_path=image_path,
+                        relative_path=relative,
+                        bucket="unlabeled",
+                        label=None,
+                    )
+                )
+    else:
+        logging.warning("Unlabeled bucket missing at %s", unlabeled_root)
+
+    if not records:
+        raise RuntimeError(f"No image files discovered under {data_dir}")
+
+    logging.info(
+        "Discovered %d images (labeled=%d, unlabeled=%d)",
+        len(records),
+        sum(1 for r in records if r.bucket == "labeled"),
+        sum(1 for r in records if r.bucket == "unlabeled"),
+    )
+    return records
+
+
+def build_transform() -> transforms.Compose:
+    """Return preprocessing transform with deterministic resizing."""
+
+    return transforms.Compose(
+        [
+            transforms.Resize(TARGET_RESIZE),
+            transforms.CenterCrop(TARGET_CROP),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
+        ]
+    )
+
+
+def load_model(device: torch.device) -> nn.Module:
+    """Load the pretrained ResNet18 backbone (penultimate layer)."""
+
+    weights = models.ResNet18_Weights.IMAGENET1K_V1
+    backbone = models.resnet18(weights=weights)
+    backbone.eval()
+    for param in backbone.parameters():
+        param.requires_grad_(False)
+
+    # Penultimate features are obtained after global average pooling
+    feature_extractor = nn.Sequential(*list(backbone.children())[:-1])
+    feature_extractor.eval()
+    feature_extractor.to(device)
+    return feature_extractor
+
+
+def preprocess_image(path: Path, transform: transforms.Compose) -> torch.Tensor:
+    """Load and preprocess an image, replicating grayscale to RGB."""
+
+    with Image.open(path) as img:
+        image_rgb = img.convert("RGB")
+        tensor = transform(image_rgb)
+    return tensor
+
+
+def batched(iterable: Sequence, batch_size: int) -> Iterable[Sequence]:
+    """Yield successive batches from a sequence."""
+
+    for start in range(0, len(iterable), batch_size):
+        end = min(start + batch_size, len(iterable))
+        yield iterable[start:end]
+
+
+def extract_embeddings(
+    records: List[ImageRecord],
+    device: torch.device,
+    batch_size: int = BATCH_SIZE,
+) -> ExtractionResults:
+    """Run feature extraction for the provided image records."""
+
+    transform = build_transform()
+    model = load_model(device)
+
+    embeddings: List[np.ndarray] = []
+    kept_records: List[ImageRecord] = []
+    failures: List[Path] = []
+    per_file_times: List[float] = []
+
+    logging.info("Beginning feature extraction over %d records", len(records))
+
+    for batch_records in batched(records, batch_size):
+        batch_tensors: List[torch.Tensor] = []
+        successful_records: List[ImageRecord] = []
+        batch_start = time.perf_counter()
+        for record in batch_records:
+            try:
+                tensor = preprocess_image(record.absolute_path, transform)
+                batch_tensors.append(tensor)
+                successful_records.append(record)
+            except (UnidentifiedImageError, OSError) as exc:
+                logging.error("Failed to decode %s: %s", record.absolute_path, exc)
+                failures.append(record.absolute_path)
+                continue
+
+        if not batch_tensors:
+            continue
+
+        batch_tensor = torch.stack(batch_tensors).to(device)
+        with torch.no_grad():
+            features = model(batch_tensor)
+        # features shape: (B, 2048, 1, 1)
+        features = torch.flatten(features, 1)
+        embeddings.append(features.cpu().numpy())
+        kept_records.extend(successful_records)
+
+        batch_duration = time.perf_counter() - batch_start
+        if successful_records:
+            per_image = batch_duration / len(successful_records)
+            per_file_times.extend([per_image] * len(successful_records))
+
+    if not embeddings:
+        raise RuntimeError("No embeddings were generated; all images failed to decode?")
+
+    embedding_matrix = np.concatenate(embeddings, axis=0)
+    logging.info("Computed embeddings with shape %s", embedding_matrix.shape)
+
+    return ExtractionResults(
+        embeddings=embedding_matrix,
+        records=kept_records,
+        failures=failures,
+        per_file_times=per_file_times,
+    )
+
+
+def compute_dataset_digest(records: Sequence[ImageRecord]) -> str:
+    """Compute a deterministic digest of the dataset contents."""
+
+    import hashlib
+
+    hasher = hashlib.sha256()
+    for record in sorted(records, key=lambda r: str(r.relative_path)):
+        stat = record.absolute_path.stat()
+        hasher.update(str(record.relative_path).encode("utf-8"))
+        hasher.update(str(stat.st_size).encode("utf-8"))
+        hasher.update(str(int(stat.st_mtime)).encode("utf-8"))
+    return hasher.hexdigest()
+
+
+def run_sanity_checks(embeddings: np.ndarray) -> Dict[str, float]:
+    """Perform basic integrity checks on the embedding matrix."""
+
+    if np.isnan(embeddings).any():
+        raise ValueError("Embedding matrix contains NaN values")
+    if np.isinf(embeddings).any():
+        raise ValueError("Embedding matrix contains inf values")
+
+    stats = {
+        "num_vectors": int(embeddings.shape[0]),
+        "dimension": int(embeddings.shape[1]),
+        "mean_abs_mean": float(np.abs(embeddings.mean(axis=0)).mean()),
+        "mean_std": float(embeddings.std(axis=0).mean()),
+    }
+
+    logging.info(
+        "Embedding stats — vectors: %d, dim: %d, mean(|mean|): %.5f, mean(std): %.5f",
+        stats["num_vectors"],
+        stats["dimension"],
+        stats["mean_abs_mean"],
+        stats["mean_std"],
+    )
+    return stats
+
+
+def nearest_neighbor_probe(
+    embeddings: np.ndarray,
+    records: Sequence[ImageRecord],
+    sample_size: int = NEIGHBOR_SAMPLE,
+    seed: int = RNG_SEED,
+) -> List[Dict[str, object]]:
+    """Compute a simple nearest-neighbor spot check on a subset."""
+
+    if embeddings.shape[0] < 2:
+        return []
+
+    rng = np.random.default_rng(seed)
+    sample_size = min(sample_size, embeddings.shape[0] - 1)
+    if sample_size <= 0:
+        return []
+
+    sample_indices = rng.choice(embeddings.shape[0], size=sample_size, replace=False)
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    norms = np.clip(norms, a_min=1e-12, a_max=None)
+    normalized = embeddings / norms
+    neighbor_records: List[Dict[str, object]] = []
+
+    for idx in sample_indices:
+        sims = normalized[idx] @ normalized.T
+        sims[idx] = -np.inf
+        neighbor_idx = int(np.argmax(sims))
+        neighbor_records.append(
+            {
+                "query": str(records[idx].relative_path),
+                "neighbor": str(records[neighbor_idx].relative_path),
+                "similarity": float(sims[neighbor_idx]),
+            }
+        )
+
+    logging.info("Nearest-neighbor probe completed for %d samples", len(neighbor_records))
+    return neighbor_records
+
+
+def save_artifacts(
+    results: ExtractionResults,
+    stats: Dict[str, float],
+    neighbor_probe: List[Dict[str, object]],
+    data_dir: Path,
+    device: torch.device,
+) -> None:
+    """Persist embeddings, CSV metadata, JSON metadata, and summary notes."""
+
+    FEATURE_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    NOTE_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    np.save(EMBEDDING_ARRAY_PATH, results.embeddings.astype(np.float32))
+
+    rows = []
+    for idx, record in enumerate(results.records):
+        rows.append(
+            {
+                "index": idx,
+                "path": str(record.relative_path),
+                "bucket": record.bucket,
+                "label": record.label,
+            }
+        )
+    import pandas as pd
+
+    df = pd.DataFrame(rows)
+    df.to_csv(EMBEDDING_CSV_PATH, index=False)
+
+    metadata = {
+        "backbone": BACKBONE_NAME,
+        "weights": BACKBONE_WEIGHTS,
+        "layer": BACKBONE_LAYER,
+        "embedding_dimension": int(results.embeddings.shape[1]),
+        "input_resize": TARGET_RESIZE,
+        "input_crop": TARGET_CROP,
+        "normalization_mean": IMAGENET_MEAN,
+        "normalization_std": IMAGENET_STD,
+        "channel_policy": "PIL RGB conversion (grayscale replicated)",
+        "date_utc": datetime.now(timezone.utc).isoformat(),
+        "num_images": int(results.embeddings.shape[0]),
+        "failed_images": len(results.failures),
+        "device": str(device),
+        "dataset_dir": str(data_dir),
+        "dataset_digest": compute_dataset_digest(results.records),
+        "sanity_checks": stats,
+        "neighbor_probe": neighbor_probe,
+    }
+
+    with METADATA_PATH.open("w", encoding="utf-8") as f:
+        json.dump(metadata, f, indent=2)
+
+    # Build Markdown summary
+    failure_section = (
+        "None"
+        if not results.failures
+        else "\n".join(f"- {path}" for path in results.failures)
+    )
+
+    mean_latency = float(np.mean(results.per_file_times)) if results.per_file_times else float("nan")
+    median_latency = float(np.median(results.per_file_times)) if results.per_file_times else float("nan")
+
+    neighbor_lines = [
+        f"| Query | Neighbor | Cosine |",
+        f"| --- | --- | --- |",
+    ]
+    for item in neighbor_probe:
+        neighbor_lines.append(
+            f"| {item['query']} | {item['neighbor']} | {item['similarity']:.4f} |"
+        )
+    neighbor_block = "\n".join(neighbor_lines) if neighbor_probe else "No neighbors computed (insufficient samples)."
+
+    summary = f"""# Feature Extraction Summary
+
+- Backbone: {BACKBONE_NAME} ({BACKBONE_WEIGHTS})
+- Layer: global average pooled features ({results.embeddings.shape[1]}-D)
+- Input spec: resize {TARGET_RESIZE} → center crop {TARGET_CROP}, RGB conversion, ImageNet normalization
+- Batch size: {BATCH_SIZE}
+- Device: {device}
+- Total images processed: {results.embeddings.shape[0]}
+- Failed decodes: {len(results.failures)}
+- Mean per-image latency (s): {mean_latency:.4f}
+- Median per-image latency (s): {median_latency:.4f}
+
+## Sanity Check Statistics
+
+- Mean of |dimension means|: {stats['mean_abs_mean']:.6f}
+- Mean of dimension standard deviations: {stats['mean_std']:.6f}
+
+## Nearest Neighbor Spot Check
+
+{neighbor_block}
+
+## Decode Failures
+
+{failure_section}
+"""
+
+    SUMMARY_NOTE_PATH.write_text(summary, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract CNN embeddings for the MRI dataset")
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DEFAULT_DATA_DIR,
+        help="Root directory containing 'avec_labels' and 'sans_label'",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Torch device to use (default: cuda if available else cpu)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=BATCH_SIZE,
+        help="Mini-batch size for inference",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    configure_logging(verbose=args.verbose)
+
+    device = torch.device(args.device)
+
+    logging.info("Starting feature extraction on device %s", device)
+    records = discover_image_records(args.data_dir)
+
+    start_time = time.perf_counter()
+    results = extract_embeddings(records, device=device, batch_size=args.batch_size)
+    duration = time.perf_counter() - start_time
+    logging.info("Completed embedding extraction in %.2f seconds", duration)
+
+    stats = run_sanity_checks(results.embeddings)
+    neighbor_probe = nearest_neighbor_probe(results.embeddings, results.records)
+    save_artifacts(results, stats, neighbor_probe, args.data_dir, device)
+    logging.info("Artifacts saved to %s", FEATURE_OUTPUT_DIR)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a feature extraction module that preprocesses MRI images and exports ResNet-18 embeddings
- document the preprocessing and inference workflow in the README and persist run metadata and summary notes
- store reproducibility artifacts including metadata, logs, and feature summary reports under outputs/

## Testing
- python -m src.feature_extraction --data-dir mri_dataset_brain_cancer_oc --device cpu --verbose